### PR TITLE
Extenstion for Start & End-Time / Better Handling of None / TimeStep

### DIFF
--- a/fmi/fmi.py
+++ b/fmi/fmi.py
@@ -15,7 +15,7 @@ from fmi.wfs_parse import (
 
 from fmi.model import OBSERVATION_PARAMS
 
-WFS_URL = "https://opendata.fmi.fi/wfs?"
+WFS_URL = "https://opendata.fmi.fi/wfs/eng?"
 
 
 async def fetch(url: str, aiohttp_kwargs: Dict[str, Any]) -> bytes:
@@ -28,16 +28,21 @@ async def fetch(url: str, aiohttp_kwargs: Dict[str, Any]) -> bytes:
 
 
 async def latest_observations(
-    place: str,
+    place: Optional[str] = None,
+    fmisid: Optional[int] = None, 
     starttime: Optional[str] = None,
+    endtime: Optional[str] = None,
     timestep: int = 10,
-    aiohttp_kwargs: Any = None,
+    aiohttp_kwargs: Any = None
 ) -> List[Observation]:
     """Fetch most recent weather observations for a specific place. Default
     is last 12 hours in 10 minute intervals.
 
     :param place: name for city or town
+    :param fmisid: id of a location
     :param starttime: fetch observations after this time. Use ISO 8601
+        format with second precision
+    :param endtime: fetch observations bevore this time. Use ISO 8601
         format with second precision
     :param timestep: interval between observations in minutes. Must be
         divisible by 10
@@ -57,7 +62,6 @@ async def latest_observations(
     params = {
         "request": "getFeature",
         "storedquery_id": "fmi::observations::weather::simple",
-        "place": place,
         "parameters": sensor_parameters,
     }
 
@@ -69,11 +73,21 @@ async def latest_observations(
 
     if starttime:
         params["starttime"] = starttime
+        
+    if endtime:
+        params["endtime"] = endtime
+        
+    if place:
+        params["place"] = place
+        
+    if fmisid:
+        params["fmisid"] = fmisid
 
     url = WFS_URL + urlencode(params)
     unparsed_gml = await fetch(url, aiohttp_kwargs)
 
     return parse_latest_observations(unparsed_gml)
+
 
 
 async def forecast(

--- a/fmi/fmi.py
+++ b/fmi/fmi.py
@@ -68,7 +68,7 @@ async def latest_observations(
     if timestep % 10 != 0:
         raise ValueError("timestep must be divisable by 10")
 
-    if timestep != 10:
+    if timestep:
         params["timestep"] = str(timestep)
 
     if starttime:

--- a/fmi/model.py
+++ b/fmi/model.py
@@ -4,6 +4,7 @@ from pprint import pformat
 from fmi.constant import OBSERVATION_CODES, FORECAST_CODES
 
 OBSERVATION_PARAMS: Dict[str, Callable[[str], Union[float, int]]] = {
+    "n_man": float,
     "t2m": float,
     "p_sea": float,
     "rh": float,
@@ -44,6 +45,7 @@ class Observation:
         humidity: int,
         temperature: float,
         timestamp: int,
+        clouds: Optional[float] = None,
         dewpoint: Optional[float] = None,
         pressure: Optional[int] = None,
         precipitation_1h: Optional[float] = None,
@@ -56,6 +58,9 @@ class Observation:
     ) -> None:
         #: dictionary of lat/lon WGS84 coordinates for the interpreted place
         self.coordinates = coordinates
+
+        #clouds 0-8
+        self.clouds = clouds
 
         #: pressure at sea level
         self.pressure = pressure

--- a/fmi/wfs_parse.py
+++ b/fmi/wfs_parse.py
@@ -134,18 +134,19 @@ def _dict_to_observation(obj: Dict[str, str]) -> Observation:
 
     return Observation(
         coordinates=Coordinates(float(obs["lat"]), float(obs["lon"])),
-        pressure=int(obs["p_sea"]) if obs.get("p_sea") else None,
-        precipitation_1h=float(obs["r_1h"]) if obs.get("r_1h") else None,
-        humidity=int(obs["rh"]),
-        snow=int(obs["snow_aws"]) if obs.get("snow_aws") else None,
-        temperature=float(obs["t2m"]),
-        dewpoint=float(obs["td"]) if obs.get("td") else None,
+        pressure=int(obs["p_sea"]) if "p_sea" in obs  else None,
+        precipitation_1h=float(obs["r_1h"]) if "r_1h" in obs else None,
+        humidity=int(obs["rh"]) if "rh" in obs else None,
+        snow=int(obs["snow_aws"]) if "snow_aws" in obs  else None,
+        temperature=float(obs["t2m"]) if "t2m" in obs else None,
+        dewpoint=float(obs["td"]) if "td" in obs else None,
         timestamp=int(obs["timestamp"]),
-        visibility=int(obs["vis"]) if obs.get("vis") else None,
-        wind_direction=int(obs["wd_10min"]) if obs.get("wd_10min") else None,
-        wind_gust=int(obs["wg_10min"]) if obs.get("wg_10min") else None,
-        wind_speed=int(obs["ws_10min"]) if obs.get("ws_10min") else None,
-        wawa=int(obs["wawa"]) if obs.get("wawa") else None,
+        visibility=int(obs["vis"]) if "vis" in obs else None,
+        wind_direction=int(obs["wd_10min"]) if "wd_10min" in obs  else None,
+        wind_gust=int(obs["wg_10min"]) if "wg_10min" in obs  else None,
+        wind_speed=int(obs["ws_10min"]) if "ws_10min" in obs  else None,
+        clouds=int(obs["n_man"]) if "n_man" in obs  else None,
+        wawa=int(obs["wawa"]) if "wawa" in obs  else None,
     )
 
 


### PR DESCRIPTION
Hi, I based my work on your API (Thank You!) and improved some things.

1. Timestep: if not given, it seams to default to 1 minute, instead of 10, so I always send the parameter if given.
2. Added support for endtime, so you can get data from a specific time range
3. Added support for cloud coverage value 'n_man'
4. changed parser logic from `if obs.get("p_sea") else None` to `if "p_sea" in obs  else None` 
    * old logic would convert 0 to None
    * New logic preservs 0, and will handle NaN from source
    * I've got data where the whole row was NaN so, I check every field